### PR TITLE
Add workflow to auto-commit clang-format fixes

### DIFF
--- a/.github/workflows/clang-format-fix.yml
+++ b/.github/workflows/clang-format-fix.yml
@@ -1,0 +1,31 @@
+name: clang-format Commit Changes
+on:
+  workflow_dispatch:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  formatting-fix:
+    name: Commit Format Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # In order to allow EndBug/add-and-commit to commit changes
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Fix C formatting issues detected by clang-format
+      uses: DoozyX/clang-format-lint-action@v0.20
+      with:
+        source: '.'
+        extensions: 'c,h'
+        clangFormatVersion: 17
+        inplace: True
+        style: file
+
+    - uses: EndBug/add-and-commit@v9
+      with:
+        author_name: github-actions
+        author_email: 41898282+github-actions[bot]@users.noreply.github.com
+        message: 'Committing clang-format changes'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,18 +17,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
-          clang-format \
           cppcheck \
           splint
-
-    - name: Check code formatting
-      run: |
-        cd vol-geotiff
-        # Check if C files are properly formatted
-        find src test -name "*.c" -o -name "*.h" | xargs clang-format --dry-run --Werror || {
-          echo "Code formatting issues found. Run 'clang-format -i src/*.c src/*.h test/*.c test/*.h' to fix."
-          exit 1
-        }
 
     - name: Static analysis with cppcheck
       run: |


### PR DESCRIPTION
This will require the repository settings to be changed to allow workflows to make commits (`settings > Actions > General > Workflow permissions`, must be set to `Read and write permissions`)

Addresses #30