### PR TITLE
Remove custom error stack from other VOL connectors

### DIFF
--- a/vol-bufr/src/bufr_vol_connector.c
+++ b/vol-bufr/src/bufr_vol_connector.c
@@ -37,8 +37,7 @@
 
 static hbool_t H5_bufr_initialized_g = FALSE;
 
-/* Identifiers for HDF5's error API */
-hid_t H5_bufr_err_stack_g = H5I_INVALID_HID;
+/* Identifier for HDF5's error API */
 hid_t H5_bufr_err_class_g = H5I_INVALID_HID;
 hid_t H5_bufr_obj_err_maj_g = H5I_INVALID_HID;
 
@@ -1659,10 +1658,6 @@ herr_t bufr_init_connector(hid_t __attribute__((unused)) vipl_id)
                                                  HDF5_VOL_BUFR_LIB_VER)) < 0)
         FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't register with HDF5 error API");
 
-    /* Create a separate error stack for the BUFR VOL to report errors with */
-    if ((H5_bufr_err_stack_g = H5Ecreate_stack()) < 0)
-        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't create error stack");
-
     /* Set up a few BUFR VOL-specific error API message classes */
     if ((H5_bufr_obj_err_maj_g =
              H5Ecreate_msg(H5_bufr_err_class_g, H5E_MAJOR, "Object interface")) < 0)
@@ -1691,16 +1686,6 @@ herr_t bufr_term_connector(void)
         if (H5Eunregister_class(H5_bufr_err_class_g) < 0)
             FUNC_DONE_ERROR(H5E_VOL, H5E_CLOSEERROR, FAIL, "can't unregister from HDF5 error API");
 
-        /* Print the current error stack before destroying it */
-        PRINT_ERROR_STACK;
-
-        /* Destroy the error stack */
-        if (H5Eclose_stack(H5_bufr_err_stack_g) < 0) {
-            FUNC_DONE_ERROR(H5E_VOL, H5E_CLOSEERROR, FAIL, "can't close error stack");
-            PRINT_ERROR_STACK;
-        }
-
-        H5_bufr_err_stack_g = H5I_INVALID_HID;
         H5_bufr_err_class_g = H5I_INVALID_HID;
         H5_bufr_obj_err_maj_g = H5I_INVALID_HID;
     }

--- a/vol-bufr/src/bufr_vol_err.h
+++ b/vol-bufr/src/bufr_vol_err.h
@@ -14,8 +14,7 @@ extern "C" {
 
 #include "H5pubconf.h"
 
-/* Identifiers for HDF5's error API */
-extern hid_t H5_bufr_err_stack_g;
+/* Identifier for HDF5's error API */
 extern hid_t H5_bufr_err_class_g;
 extern hid_t H5_bufr_obj_err_maj_g;
 
@@ -50,8 +49,8 @@ extern hid_t H5_bufr_obj_err_maj_g;
         /* Check whether automatic error reporting has been disabled */                            \
         (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
         if (err_func) {                                                                            \
-            if (H5_bufr_err_stack_g >= 0 && H5_bufr_err_class_g >= 0) {                            \
-                H5Epush2(H5_bufr_err_stack_g, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,   \
+            if (H5_bufr_err_class_g >= 0) {                                                       \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,           \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -77,8 +76,8 @@ extern hid_t H5_bufr_obj_err_maj_g;
         /* Check whether automatic error reporting has been disabled */                            \
         (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
         if (err_func) {                                                                            \
-            if (H5_bufr_err_stack_g >= 0 && H5_bufr_err_class_g >= 0)                              \
-                H5Epush2(H5_bufr_err_stack_g, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,   \
+            if (H5_bufr_err_class_g >= 0)                                                          \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,           \
                          err_major, err_minor, __VA_ARGS__);                                       \
             else {                                                                                 \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -87,24 +86,6 @@ extern hid_t H5_bufr_obj_err_maj_g;
         }                                                                                          \
                                                                                                    \
         ret_value = ret_val;                                                                       \
-    } while (0)
-
-/*
- * Macro to print out the BUFR VOL connector's current error stack
- * and then clear it for future use. (v2 errors only)
- */
-#define PRINT_ERROR_STACK                                                                          \
-    do {                                                                                           \
-        H5E_auto2_t err_func;                                                                      \
-                                                                                                   \
-        /* Check whether automatic error reporting has been disabled */                            \
-        (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
-        if (err_func) {                                                                            \
-            if ((H5_bufr_err_stack_g >= 0) && (H5Eget_num(H5_bufr_err_stack_g) > 0)) {             \
-                H5Eprint2(H5_bufr_err_stack_g, NULL);                                              \
-                H5Eclear2(H5_bufr_err_stack_g);                                                    \
-            }                                                                                      \
-        }                                                                                          \
     } while (0)
 
 #else
@@ -132,8 +113,8 @@ extern hid_t H5_bufr_obj_err_maj_g;
                                                                                                    \
         /* Check whether automatic error reporting has been disabled */                            \
         if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if (H5_bufr_err_stack_g >= 0 && H5_bufr_err_class_g >= 0) {                            \
-                H5Epush2(H5_bufr_err_stack_g, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,   \
+            if (H5_bufr_err_class_g >= 0) {                                                       \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,           \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -171,8 +152,8 @@ extern hid_t H5_bufr_obj_err_maj_g;
                                                                                                    \
         /* Check whether automatic error reporting has been disabled */                            \
         if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if (H5_bufr_err_stack_g >= 0 && H5_bufr_err_class_g >= 0) {                            \
-                H5Epush2(H5_bufr_err_stack_g, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,   \
+            if (H5_bufr_err_class_g >= 0) {                                                       \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_bufr_err_class_g,           \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -181,35 +162,6 @@ extern hid_t H5_bufr_obj_err_maj_g;
         }                                                                                          \
                                                                                                    \
         ret_value = ret_val;                                                                       \
-    } while (0)
-
-/*
- * Macro to print out the BUFR VOL connector's current error stack
- * and then clear it for future use. (compatible with v1 and v2 errors)
- */
-#define PRINT_ERROR_STACK                                                                          \
-    do {                                                                                           \
-        unsigned is_v2_err;                                                                        \
-        union {                                                                                    \
-            H5E_auto1_t err_func_v1;                                                               \
-            H5E_auto2_t err_func_v2;                                                               \
-        } err_func;                                                                                \
-                                                                                                   \
-        /* Determine version of error */                                                           \
-        (void) H5Eauto_is_v2(H5E_DEFAULT, &is_v2_err);                                             \
-                                                                                                   \
-        if (is_v2_err)                                                                             \
-            (void) H5Eget_auto2(H5E_DEFAULT, &err_func.err_func_v2, NULL);                         \
-        else                                                                                       \
-            (void) H5Eget_auto1(&err_func.err_func_v1, NULL);                                      \
-                                                                                                   \
-        /* Check whether automatic error reporting has been disabled */                            \
-        if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if ((H5_bufr_err_stack_g >= 0) && (H5Eget_num(H5_bufr_err_stack_g) > 0)) {             \
-                H5Eprint2(H5_bufr_err_stack_g, NULL);                                              \
-                H5Eclear2(H5_bufr_err_stack_g);                                                    \
-            }                                                                                      \
-        }                                                                                          \
     } while (0)
 
 #endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/vol-cdf/src/cdf_vol_connector.c
+++ b/vol-cdf/src/cdf_vol_connector.c
@@ -40,8 +40,7 @@
 
 static hbool_t H5_cdf_initialized_g = FALSE;
 
-/* Identifiers for HDF5's error API */
-hid_t H5_cdf_err_stack_g = H5I_INVALID_HID;
+/* Identifier for HDF5's error API */
 hid_t H5_cdf_err_class_g = H5I_INVALID_HID;
 hid_t H5_cdf_obj_err_maj_g = H5I_INVALID_HID;
 
@@ -2352,10 +2351,6 @@ herr_t cdf_init_connector(hid_t __attribute__((unused)) vipl_id)
                                                 HDF5_VOL_CDF_LIB_VER)) < 0)
         FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't register with HDF5 error API");
 
-    /* Create a separate error stack for the CDF VOL to report errors with */
-    if ((H5_cdf_err_stack_g = H5Ecreate_stack()) < 0)
-        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't create error stack");
-
     /* Set up a few CDF VOL-specific error API message classes */
     if ((H5_cdf_obj_err_maj_g = H5Ecreate_msg(H5_cdf_err_class_g, H5E_MAJOR, "Object interface")) <
         0)
@@ -2384,16 +2379,6 @@ herr_t cdf_term_connector(void)
         if (H5Eunregister_class(H5_cdf_err_class_g) < 0)
             FUNC_DONE_ERROR(H5E_VOL, H5E_CLOSEERROR, FAIL, "can't unregister from HDF5 error API");
 
-        /* Print the current error stack before destroying it */
-        PRINT_ERROR_STACK;
-
-        /* Destroy the error stack */
-        if (H5Eclose_stack(H5_cdf_err_stack_g) < 0) {
-            FUNC_DONE_ERROR(H5E_VOL, H5E_CLOSEERROR, FAIL, "can't close error stack");
-            PRINT_ERROR_STACK;
-        }
-
-        H5_cdf_err_stack_g = H5I_INVALID_HID;
         H5_cdf_err_class_g = H5I_INVALID_HID;
         H5_cdf_obj_err_maj_g = H5I_INVALID_HID;
     }

--- a/vol-cdf/src/cdf_vol_err.h
+++ b/vol-cdf/src/cdf_vol_err.h
@@ -25,8 +25,7 @@ extern "C" {
 
 #include "H5pubconf.h"
 
-/* Identifiers for HDF5's error API */
-extern hid_t H5_cdf_err_stack_g;
+/* Identifier for HDF5's error API */
 extern hid_t H5_cdf_err_class_g;
 extern hid_t H5_cdf_obj_err_maj_g;
 
@@ -61,8 +60,8 @@ extern hid_t H5_cdf_obj_err_maj_g;
         /* Check whether automatic error reporting has been disabled */                            \
         (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
         if (err_func) {                                                                            \
-            if (H5_cdf_err_stack_g >= 0 && H5_cdf_err_class_g >= 0) {                              \
-                H5Epush2(H5_cdf_err_stack_g, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,     \
+            if (H5_cdf_err_class_g >= 0) {                                                         \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,            \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -88,8 +87,8 @@ extern hid_t H5_cdf_obj_err_maj_g;
         /* Check whether automatic error reporting has been disabled */                            \
         (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
         if (err_func) {                                                                            \
-            if (H5_cdf_err_stack_g >= 0 && H5_cdf_err_class_g >= 0)                                \
-                H5Epush2(H5_cdf_err_stack_g, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,     \
+            if (H5_cdf_err_class_g >= 0)                                                            \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,            \
                          err_major, err_minor, __VA_ARGS__);                                       \
             else {                                                                                 \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -98,24 +97,6 @@ extern hid_t H5_cdf_obj_err_maj_g;
         }                                                                                          \
                                                                                                    \
         ret_value = ret_val;                                                                       \
-    } while (0)
-
-/*
- * Macro to print out the CDF VOL connector's current error stack
- * and then clear it for future use. (v2 errors only)
- */
-#define PRINT_ERROR_STACK                                                                          \
-    do {                                                                                           \
-        H5E_auto2_t err_func;                                                                      \
-                                                                                                   \
-        /* Check whether automatic error reporting has been disabled */                            \
-        (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
-        if (err_func) {                                                                            \
-            if ((H5_cdf_err_stack_g >= 0) && (H5Eget_num(H5_cdf_err_stack_g) > 0)) {               \
-                H5Eprint2(H5_cdf_err_stack_g, NULL);                                               \
-                H5Eclear2(H5_cdf_err_stack_g);                                                     \
-            }                                                                                      \
-        }                                                                                          \
     } while (0)
 
 #else
@@ -143,8 +124,8 @@ extern hid_t H5_cdf_obj_err_maj_g;
                                                                                                    \
         /* Check whether automatic error reporting has been disabled */                            \
         if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if (H5_cdf_err_stack_g >= 0 && H5_cdf_err_class_g >= 0) {                              \
-                H5Epush2(H5_cdf_err_stack_g, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,     \
+            if (H5_cdf_err_class_g >= 0) {                                                         \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,            \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -182,8 +163,8 @@ extern hid_t H5_cdf_obj_err_maj_g;
                                                                                                    \
         /* Check whether automatic error reporting has been disabled */                            \
         if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if (H5_cdf_err_stack_g >= 0 && H5_cdf_err_class_g >= 0) {                              \
-                H5Epush2(H5_cdf_err_stack_g, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,     \
+            if (H5_cdf_err_class_g >= 0) {                                                         \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_cdf_err_class_g,            \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -192,35 +173,6 @@ extern hid_t H5_cdf_obj_err_maj_g;
         }                                                                                          \
                                                                                                    \
         ret_value = ret_val;                                                                       \
-    } while (0)
-
-/*
- * Macro to print out the CDF VOL connector's current error stack
- * and then clear it for future use. (compatible with v1 and v2 errors)
- */
-#define PRINT_ERROR_STACK                                                                          \
-    do {                                                                                           \
-        unsigned is_v2_err;                                                                        \
-        union {                                                                                    \
-            H5E_auto1_t err_func_v1;                                                               \
-            H5E_auto2_t err_func_v2;                                                               \
-        } err_func;                                                                                \
-                                                                                                   \
-        /* Determine version of error */                                                           \
-        (void) H5Eauto_is_v2(H5E_DEFAULT, &is_v2_err);                                             \
-                                                                                                   \
-        if (is_v2_err)                                                                             \
-            (void) H5Eget_auto2(H5E_DEFAULT, &err_func.err_func_v2, NULL);                         \
-        else                                                                                       \
-            (void) H5Eget_auto1(&err_func.err_func_v1, NULL);                                      \
-                                                                                                   \
-        /* Check whether automatic error reporting has been disabled */                            \
-        if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if ((H5_cdf_err_stack_g >= 0) && (H5Eget_num(H5_cdf_err_stack_g) > 0)) {               \
-                H5Eprint2(H5_cdf_err_stack_g, NULL);                                               \
-                H5Eclear2(H5_cdf_err_stack_g);                                                     \
-            }                                                                                      \
-        }                                                                                          \
     } while (0)
 
 #endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/vol-grib2/src/grib2_vol_connector.c
+++ b/vol-grib2/src/grib2_vol_connector.c
@@ -40,8 +40,7 @@
 
 static hbool_t H5_grib2_initialized_g = FALSE;
 
-/* Identifiers for HDF5's error API */
-hid_t H5_grib2_err_stack_g = H5I_INVALID_HID;
+/* Identifier for HDF5's error API */
 hid_t H5_grib2_err_class_g = H5I_INVALID_HID;
 hid_t H5_grib2_obj_err_maj_g = H5I_INVALID_HID;
 
@@ -2425,10 +2424,6 @@ herr_t grib2_init_connector(hid_t __attribute__((unused)) vipl_id)
              HDF5_VOL_GRIB2_ERR_CLS_NAME, HDF5_VOL_GRIB2_LIB_NAME, HDF5_VOL_GRIB2_LIB_VER)) < 0)
         FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't register with HDF5 error API");
 
-    /* Create a separate error stack for the GRIB2 VOL to report errors with */
-    if ((H5_grib2_err_stack_g = H5Ecreate_stack()) < 0)
-        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't create error stack");
-
     /* Set up a few GRIB2 VOL-specific error API message classes */
     if ((H5_grib2_obj_err_maj_g =
              H5Ecreate_msg(H5_grib2_err_class_g, H5E_MAJOR, "Object interface")) < 0)
@@ -2457,16 +2452,6 @@ herr_t grib2_term_connector(void)
         if (H5Eunregister_class(H5_grib2_err_class_g) < 0)
             FUNC_DONE_ERROR(H5E_VOL, H5E_CLOSEERROR, FAIL, "can't unregister from HDF5 error API");
 
-        /* Print the current error stack before destroying it */
-        PRINT_ERROR_STACK;
-
-        /* Destroy the error stack */
-        if (H5Eclose_stack(H5_grib2_err_stack_g) < 0) {
-            FUNC_DONE_ERROR(H5E_VOL, H5E_CLOSEERROR, FAIL, "can't close error stack");
-            PRINT_ERROR_STACK;
-        }
-
-        H5_grib2_err_stack_g = H5I_INVALID_HID;
         H5_grib2_err_class_g = H5I_INVALID_HID;
         H5_grib2_obj_err_maj_g = H5I_INVALID_HID;
     }

--- a/vol-grib2/src/grib2_vol_err.h
+++ b/vol-grib2/src/grib2_vol_err.h
@@ -14,8 +14,7 @@ extern "C" {
 
 #include "H5pubconf.h"
 
-/* Identifiers for HDF5's error API */
-extern hid_t H5_grib2_err_stack_g;
+/* Identifier for HDF5's error API */
 extern hid_t H5_grib2_err_class_g;
 extern hid_t H5_grib2_obj_err_maj_g;
 
@@ -50,8 +49,8 @@ extern hid_t H5_grib2_obj_err_maj_g;
         /* Check whether automatic error reporting has been disabled */                            \
         (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
         if (err_func) {                                                                            \
-            if (H5_grib2_err_stack_g >= 0 && H5_grib2_err_class_g >= 0) {                          \
-                H5Epush2(H5_grib2_err_stack_g, __FILE__, __func__, __LINE__, H5_grib2_err_class_g, \
+            if (H5_grib2_err_class_g >= 0) {                                                       \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_grib2_err_class_g,          \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -77,8 +76,8 @@ extern hid_t H5_grib2_obj_err_maj_g;
         /* Check whether automatic error reporting has been disabled */                            \
         (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
         if (err_func) {                                                                            \
-            if (H5_grib2_err_stack_g >= 0 && H5_grib2_err_class_g >= 0)                            \
-                H5Epush2(H5_grib2_err_stack_g, __FILE__, __func__, __LINE__, H5_grib2_err_class_g, \
+            if (H5_grib2_err_class_g >= 0)                                                          \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_grib2_err_class_g,          \
                          err_major, err_minor, __VA_ARGS__);                                       \
             else {                                                                                 \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -87,24 +86,6 @@ extern hid_t H5_grib2_obj_err_maj_g;
         }                                                                                          \
                                                                                                    \
         ret_value = ret_val;                                                                       \
-    } while (0)
-
-/*
- * Macro to print out the GRIB2 VOL connector's current error stack
- * and then clear it for future use. (v2 errors only)
- */
-#define PRINT_ERROR_STACK                                                                          \
-    do {                                                                                           \
-        H5E_auto2_t err_func;                                                                      \
-                                                                                                   \
-        /* Check whether automatic error reporting has been disabled */                            \
-        (void) H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);                                         \
-        if (err_func) {                                                                            \
-            if ((H5_grib2_err_stack_g >= 0) && (H5Eget_num(H5_grib2_err_stack_g) > 0)) {           \
-                H5Eprint2(H5_grib2_err_stack_g, NULL);                                             \
-                H5Eclear2(H5_grib2_err_stack_g);                                                   \
-            }                                                                                      \
-        }                                                                                          \
     } while (0)
 
 #else
@@ -132,8 +113,8 @@ extern hid_t H5_grib2_obj_err_maj_g;
                                                                                                    \
         /* Check whether automatic error reporting has been disabled */                            \
         if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if (H5_grib2_err_stack_g >= 0 && H5_grib2_err_class_g >= 0) {                          \
-                H5Epush2(H5_grib2_err_stack_g, __FILE__, __func__, __LINE__, H5_grib2_err_class_g, \
+            if (H5_grib2_err_class_g >= 0) {                                                       \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_grib2_err_class_g,          \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -171,8 +152,8 @@ extern hid_t H5_grib2_obj_err_maj_g;
                                                                                                    \
         /* Check whether automatic error reporting has been disabled */                            \
         if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if (H5_grib2_err_stack_g >= 0 && H5_grib2_err_class_g >= 0) {                          \
-                H5Epush2(H5_grib2_err_stack_g, __FILE__, __func__, __LINE__, H5_grib2_err_class_g, \
+            if (H5_grib2_err_class_g >= 0) {                                                       \
+                H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5_grib2_err_class_g,          \
                          err_major, err_minor, __VA_ARGS__);                                       \
             } else {                                                                               \
                 fprintf(stderr, __VA_ARGS__);                                                      \
@@ -181,35 +162,6 @@ extern hid_t H5_grib2_obj_err_maj_g;
         }                                                                                          \
                                                                                                    \
         ret_value = ret_val;                                                                       \
-    } while (0)
-
-/*
- * Macro to print out the GRIB2 VOL connector's current error stack
- * and then clear it for future use. (compatible with v1 and v2 errors)
- */
-#define PRINT_ERROR_STACK                                                                          \
-    do {                                                                                           \
-        unsigned is_v2_err;                                                                        \
-        union {                                                                                    \
-            H5E_auto1_t err_func_v1;                                                               \
-            H5E_auto2_t err_func_v2;                                                               \
-        } err_func;                                                                                \
-                                                                                                   \
-        /* Determine version of error */                                                           \
-        (void) H5Eauto_is_v2(H5E_DEFAULT, &is_v2_err);                                             \
-                                                                                                   \
-        if (is_v2_err)                                                                             \
-            (void) H5Eget_auto2(H5E_DEFAULT, &err_func.err_func_v2, NULL);                         \
-        else                                                                                       \
-            (void) H5Eget_auto1(&err_func.err_func_v1, NULL);                                      \
-                                                                                                   \
-        /* Check whether automatic error reporting has been disabled */                            \
-        if ((is_v2_err && err_func.err_func_v2) || (!is_v2_err && err_func.err_func_v1)) {         \
-            if ((H5_grib2_err_stack_g >= 0) && (H5Eget_num(H5_grib2_err_stack_g) > 0)) {           \
-                H5Eprint2(H5_grib2_err_stack_g, NULL);                                             \
-                H5Eclear2(H5_grib2_err_stack_g);                                                   \
-            }                                                                                      \
-        }                                                                                          \
     } while (0)
 
 #endif /* H5_NO_DEPRECATED_SYMBOLS */


### PR DESCRIPTION
Implements the same changes as #40 for the BUFR, CDF, and GRIB2 VOL connectors.